### PR TITLE
Revert "Update the Drupal Core"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image
-FROM drupal:7.58
+FROM drupal:7.53
 
 MAINTAINER OBiBa <dev@obiba.org>
 


### PR DESCRIPTION
Reverts obiba/docker-mica-drupal#11

php5-mysql and php5-curl missing packages have to be solved properly.